### PR TITLE
feat: add full-stack sales simulation platform scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+API_KEY=super-secret-key
+OPENAI_API_KEY=sk-your-openai-key
+REALTIME_MODEL=gpt-4o-realtime-preview
+RESPONSES_MODEL=gpt-4o-mini

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+frontend/dist
+backend/dist
+.eslintrc.cjs

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,47 @@
+module.exports = {
+  root: true,
+  ignorePatterns: ['node_modules', 'dist', 'build'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'react', 'react-hooks'],
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  parserOptions: {
+    ecmaVersion: 2023,
+    sourceType: 'module'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  overrides: [
+    {
+      files: ['frontend/**/*.{ts,tsx}'],
+      env: {
+        browser: true,
+        es2021: true
+      },
+      parserOptions: {
+        project: './frontend/tsconfig.json'
+      },
+      rules: {
+        'react/react-in-jsx-scope': 'off'
+      }
+    },
+    {
+      files: ['backend/**/*.ts'],
+      env: {
+        node: true,
+        es2021: true
+      },
+      parserOptions: {
+        project: './backend/tsconfig.json'
+      }
+    }
+  ]
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+dist
+.DS_Store
+.env
+frontend/dist
+backend/dist
+postgres_data

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "semi": true
+}

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.env
+dist

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+API_KEY=super-secret-key
+OPENAI_API_KEY=sk-your-openai-key
+DATABASE_URL=postgresql://postgres:postgres@db:5432/sales_simulation
+REALTIME_MODEL=gpt-4o-realtime-preview
+RESPONSES_MODEL=gpt-4o-mini

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY tsconfig.json ./
+COPY prisma ./prisma
+COPY src ./src
+
+RUN npx prisma generate
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 4000
+CMD ["node", "dist/server.js"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "sales-simulation-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy"
+  },
+  "dependencies": {
+    "@fastify/cors": "^9.0.1",
+    "@fastify/sensible": "^5.6.0",
+    "@prisma/client": "^5.22.0",
+    "dotenv": "^16.4.5",
+    "fastify": "^4.28.1",
+    "fastify-type-provider-zod": "^2.1.0",
+    "node-fetch": "^3.3.2",
+    "pino": "^9.4.0",
+    "prisma": "^5.22.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.10",
+    "@types/node-fetch": "^2.6.11",
+    "@typescript-eslint/eslint-plugin": "^8.7.0",
+    "@typescript-eslint/parser": "^8.7.0",
+    "eslint": "^9.10.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.3.3",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Conversation {
+  id         String   @id @default(cuid())
+  userId     String   @default("demo-user")
+  transcript String?
+  score      Int?
+  feedback   String?
+  createdAt  DateTime @default(now())
+}

--- a/backend/src/lib/env.ts
+++ b/backend/src/lib/env.ts
@@ -1,0 +1,23 @@
+import { config } from 'dotenv';
+import { z } from 'zod';
+
+config();
+
+const envSchema = z.object({
+  NODE_ENV: z.string().default('development'),
+  PORT: z.coerce.number().default(4000),
+  API_KEY: z.string(),
+  OPENAI_API_KEY: z.string(),
+  REALTIME_MODEL: z.string().default('gpt-4o-realtime-preview'),
+  RESPONSES_MODEL: z.string().default('gpt-4o-mini'),
+  DATABASE_URL: z.string().url()
+});
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  console.error('Invalid environment variables', parsed.error.flatten().fieldErrors);
+  throw new Error('Invalid environment configuration');
+}
+
+export const env = parsed.data;

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/backend/src/routes/conversation.ts
+++ b/backend/src/routes/conversation.ts
@@ -1,0 +1,99 @@
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { prisma } from '../lib/prisma.js';
+import type { ConversationDto, ConversationResponse } from '../types/index.js';
+
+export async function conversationRoutes(app: FastifyInstance) {
+  app.withTypeProvider<ZodTypeProvider>().post(
+    '/api/start',
+    {
+      schema: {
+        body: z
+          .object({
+            userId: z.string().optional()
+          })
+          .optional(),
+        response: {
+          200: z.object({ conversationId: z.string() })
+        }
+      }
+    },
+    async (request, reply) => {
+      const conversation = await prisma.conversation.create({
+        data: {
+          userId: request.body?.userId ?? 'demo-user'
+        }
+      });
+
+      return reply.send({ conversationId: conversation.id });
+    }
+  );
+
+  app.withTypeProvider<ZodTypeProvider>().post(
+    '/api/conversation/:id/transcript',
+    {
+      schema: {
+        params: z.object({
+          id: z.string()
+        }),
+        body: z.object({
+          transcript: z.string().min(1)
+        }),
+        response: {
+          200: z.object({
+            id: z.string(),
+            transcript: z.string().nullable(),
+            score: z.number().nullable(),
+            feedback: z.string().nullable(),
+            createdAt: z.string()
+          })
+        }
+      }
+    },
+    async (request, reply) => {
+      const conversation = await prisma.conversation.update({
+        where: { id: request.params.id },
+        data: { transcript: request.body.transcript }
+      });
+
+      return reply.send(formatConversation(conversation));
+    }
+  );
+
+  app.withTypeProvider<ZodTypeProvider>().get(
+    '/api/conversation/:id',
+    {
+      schema: {
+        params: z.object({ id: z.string() }),
+        response: {
+          200: z.object({
+            id: z.string(),
+            transcript: z.string().nullable(),
+            score: z.number().nullable(),
+            feedback: z.string().nullable(),
+            createdAt: z.string()
+          })
+        }
+      }
+    },
+    async (request, reply) => {
+      const conversation = await prisma.conversation.findUnique({
+        where: { id: request.params.id }
+      });
+
+      if (!conversation) {
+        return reply.notFound('Conversation not found');
+      }
+
+      return reply.send(formatConversation(conversation));
+    }
+  );
+}
+
+function formatConversation(conversation: ConversationResponse): ConversationDto {
+  return {
+    ...conversation,
+    createdAt: conversation.createdAt.toISOString()
+  };
+}

--- a/backend/src/routes/realtime.ts
+++ b/backend/src/routes/realtime.ts
@@ -1,0 +1,45 @@
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import fetch from 'node-fetch';
+import { env } from '../lib/env.js';
+
+export async function realtimeRoutes(app: FastifyInstance) {
+  app.withTypeProvider<ZodTypeProvider>().post(
+    '/api/realtime/session',
+    {
+      schema: {
+        body: z.object({
+          sdp: z.string(),
+          conversationId: z.string(),
+          token: z.string().optional()
+        }),
+        response: {
+          200: z.object({ sdp: z.string() })
+        }
+      }
+    },
+    async (request, reply) => {
+      const bearerToken = request.body.token ?? env.OPENAI_API_KEY;
+
+      const response = await fetch(`https://api.openai.com/v1/realtime?model=${env.REALTIME_MODEL}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${bearerToken}`,
+          'Content-Type': 'application/sdp',
+          'OpenAI-Beta': 'realtime=v1'
+        },
+        body: request.body.sdp
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        request.log.error({ errorText }, 'Failed to negotiate WebRTC session');
+        return reply.status(500).send({ message: 'Realtime negotiation failed' });
+      }
+
+      const answer = await response.text();
+      return reply.send({ sdp: answer });
+    }
+  );
+}

--- a/backend/src/routes/score.ts
+++ b/backend/src/routes/score.ts
@@ -1,0 +1,141 @@
+import type { FastifyInstance } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import fetch from 'node-fetch';
+import { env } from '../lib/env.js';
+import { prisma } from '../lib/prisma.js';
+
+const systemPrompt = `Bewerte dieses Verkaufsgespräch nach Klarheit, Bedarfsermittlung, Einwandbehandlung.
+Antworte ausschließlich als JSON im Format {"score": number, "feedback": string}.`;
+
+export async function scoreRoutes(app: FastifyInstance) {
+  app.withTypeProvider<ZodTypeProvider>().post(
+    '/api/score',
+    {
+      schema: {
+        body: z.object({
+          conversationId: z.string().optional(),
+          transcript: z.string().optional()
+        }),
+        response: {
+          200: z.object({
+            conversationId: z.string(),
+            score: z.number(),
+            feedback: z.string()
+          })
+        }
+      }
+    },
+    async (request, reply) => {
+      const { conversationId, transcript: transcriptFromBody } = request.body;
+
+      if (!conversationId && !transcriptFromBody) {
+        return reply.badRequest('conversationId oder transcript erforderlich');
+      }
+
+      const conversation = conversationId
+        ? await prisma.conversation.findUnique({ where: { id: conversationId } })
+        : null;
+
+      if (conversationId && !conversation) {
+        return reply.notFound('Conversation not found');
+      }
+
+      const transcript = transcriptFromBody ?? conversation?.transcript;
+
+      if (!transcript) {
+        return reply.badRequest('Kein Transkript vorhanden');
+      }
+
+      const response = await fetch('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: env.RESPONSES_MODEL,
+          input: [
+            {
+              role: 'system',
+              content: [
+                {
+                  type: 'text',
+                  text: systemPrompt
+                }
+              ]
+            },
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'text',
+                  text: transcript
+                }
+              ]
+            }
+          ]
+        })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        request.log.error({ errorText }, 'Failed to fetch score from OpenAI');
+        return reply.status(500).send({ message: 'Score request failed' });
+      }
+
+      const payload = (await response.json()) as Record<string, unknown> & {
+        output?: Array<{
+          content?: Array<{
+            text?: string;
+          }>;
+        }>;
+        content?: Array<{
+          text?: string;
+        }>;
+      };
+
+      const textContent =
+        payload.output?.[0]?.content?.[0]?.text ??
+        payload.content?.[0]?.text ??
+        '';
+
+      let parsed: { score: number; feedback: string } | null = null;
+
+      try {
+        const jsonMatch = textContent.match(/\{[\s\S]*\}/);
+        if (jsonMatch) {
+          parsed = JSON.parse(jsonMatch[0]) as { score: number; feedback: string };
+        }
+      } catch (error) {
+        request.log.warn({ error }, 'Failed to parse score payload');
+      }
+
+      if (!parsed) {
+        return reply.status(500).send({ message: 'Antwort konnte nicht interpretiert werden' });
+      }
+
+      const boundedScore = Math.min(100, Math.max(0, Math.round(parsed.score)));
+
+      const updatedConversation = conversationId
+        ? await prisma.conversation.update({
+            where: { id: conversationId },
+            data: { score: boundedScore, feedback: parsed.feedback }
+          })
+        : await prisma.conversation.create({
+            data: {
+              userId: 'demo-user',
+              transcript,
+              score: boundedScore,
+              feedback: parsed.feedback
+            }
+          });
+
+      return reply.send({
+        conversationId: updatedConversation.id,
+        score: boundedScore,
+        feedback: parsed.feedback
+      });
+    }
+  );
+}

--- a/backend/src/routes/token.ts
+++ b/backend/src/routes/token.ts
@@ -1,0 +1,59 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import fetch from 'node-fetch';
+import { env } from '../lib/env.js';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+export async function tokenRoutes(app: FastifyInstance) {
+  app.withTypeProvider<ZodTypeProvider>().post(
+    '/api/token',
+    {
+      schema: {
+        body: z
+          .object({
+            model: z.string().optional()
+          })
+          .optional(),
+        response: {
+          200: z.object({
+            token: z.string(),
+            expires_in: z.number()
+          })
+        }
+      }
+    },
+    async (request, reply) => {
+      const model = request.body?.model ?? env.REALTIME_MODEL;
+
+      const response = await fetch('https://api.openai.com/v1/realtime/sessions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+          'OpenAI-Beta': 'realtime=v1'
+        },
+        body: JSON.stringify({ model })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        request.log.error({ errorText }, 'Failed to create ephemeral token');
+        return reply.status(500).send({ message: 'Failed to create ephemeral token' });
+      }
+
+      const payload = (await response.json()) as {
+        client_secret: {
+          value: string;
+          expires_at: number;
+        };
+      };
+
+      const expiresIn = Math.max(0, Math.floor(payload.client_secret.expires_at - Date.now() / 1000));
+
+      return reply.send({
+        token: payload.client_secret.value,
+        expires_in: expiresIn
+      });
+    }
+  );
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,60 @@
+import Fastify from 'fastify';
+import sensible from '@fastify/sensible';
+import cors from '@fastify/cors';
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import { env } from './lib/env.js';
+import { prisma } from './lib/prisma.js';
+import { conversationRoutes } from './routes/conversation.js';
+import { tokenRoutes } from './routes/token.js';
+import { realtimeRoutes } from './routes/realtime.js';
+import { scoreRoutes } from './routes/score.js';
+
+const buildServer = () => {
+  const app = Fastify({
+    logger: true
+  });
+
+  app.setValidatorCompiler(validatorCompiler);
+  app.setSerializerCompiler(serializerCompiler);
+
+  app.register(cors, { origin: true });
+  app.register(sensible);
+
+  app.addHook('onRequest', async (request, reply) => {
+    if (!request.url.startsWith('/api')) {
+      return;
+    }
+
+    const apiKey = request.headers['x-api-key'];
+    if (apiKey !== env.API_KEY) {
+      return reply.status(401).send({ message: 'Unauthorized' });
+    }
+  });
+
+  app.addHook('onClose', async () => {
+    await prisma.$disconnect();
+  });
+
+  app.register(conversationRoutes);
+  app.register(tokenRoutes);
+  app.register(realtimeRoutes);
+  app.register(scoreRoutes);
+
+  return app;
+};
+
+export const app = buildServer();
+
+export async function start() {
+  try {
+    await app.listen({ port: env.PORT, host: '0.0.0.0' });
+    app.log.info(`Server running on http://0.0.0.0:${env.PORT}`);
+  } catch (error) {
+    app.log.error(error);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  start();
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,0 +1,11 @@
+import type { Conversation } from '@prisma/client';
+
+export type ConversationResponse = Conversation;
+
+export type ConversationDto = {
+  id: string;
+  transcript: string | null;
+  score: number | null;
+  feedback: string | null;
+  createdAt: string;
+};

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: sales-simulation-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sales_simulation
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ./backend
+    container_name: sales-simulation-backend
+    depends_on:
+      - db
+    environment:
+      NODE_ENV: production
+      PORT: 4000
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/sales_simulation
+      API_KEY: ${API_KEY:-super-secret-key}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-replace-me}
+      REALTIME_MODEL: ${REALTIME_MODEL:-gpt-4o-realtime-preview}
+      RESPONSES_MODEL: ${RESPONSES_MODEL:-gpt-4o-mini}
+    ports:
+      - '4000:4000'
+    command: sh -c "npx prisma migrate deploy && node dist/server.js"
+
+  frontend:
+    build:
+      context: ./frontend
+    container_name: sales-simulation-frontend
+    depends_on:
+      - backend
+    environment:
+      VITE_API_KEY: ${API_KEY:-super-secret-key}
+    ports:
+      - '3000:3000'
+    command: npm run dev -- --host 0.0.0.0 --port 3000
+
+volumes:
+  postgres_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+npm-debug.log
+.env

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_KEY=super-secret-key

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY tsconfig.json tsconfig.node.json vite.config.ts ./
+COPY index.html ./
+COPY src ./src
+
+EXPOSE 3000
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "3000"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sales Simulation</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "sales-simulation-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^8.7.0",
+    "@typescript-eslint/parser": "^8.7.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "eslint": "^9.10.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-refresh": "^0.4.12",
+    "prettier": "^3.3.3",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,129 @@
+import { useMemo } from 'react';
+import { useSimulation } from './hooks/useSimulation';
+import styles from './styles/App.module.css';
+
+function StatusBadge({ status }: { status: string }) {
+  const label = useMemo(() => {
+    switch (status) {
+      case 'starting':
+        return 'Verbindung wird aufgebaut...';
+      case 'live':
+        return 'Simulation läuft';
+      case 'ended':
+        return 'Simulation beendet';
+      case 'error':
+        return 'Fehler';
+      default:
+        return 'Bereit';
+    }
+  }, [status]);
+
+  const statusClass = useMemo(() => {
+    switch (status) {
+      case 'starting':
+        return styles.badgeStarting;
+      case 'live':
+        return styles.badgeLive;
+      case 'ended':
+        return styles.badgeEnded;
+      case 'error':
+        return styles.badgeError;
+      default:
+        return undefined;
+    }
+  }, [status]);
+
+  return <span className={`${styles.badge} ${statusClass ?? ''}`}>{label}</span>;
+}
+
+function App() {
+  const {
+    audioRef,
+    conversationId,
+    endSimulation,
+    error,
+    fetchTranscript,
+    requestScore,
+    saveTranscript,
+    score,
+    startSimulation,
+    status,
+    transcript,
+    transcriptDraft,
+    setTranscriptDraft
+  } = useSimulation();
+
+  const canStart = status === 'idle' || status === 'ended' || status === 'error';
+  const canStop = status === 'live';
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div>
+          <h1>KI Verkaufssimulation</h1>
+          <p>Trainiere dein Verkaufsgespräch mit einer Realtime-KI.</p>
+        </div>
+        <StatusBadge status={status} />
+      </header>
+
+      <main className={styles.main}>
+        <section className={styles.card}>
+          <h2>Simulation steuern</h2>
+          <p>Starte die Simulation und sprich mit der KI über dein Angebot.</p>
+          <div className={styles.actions}>
+            <button type="button" onClick={startSimulation} disabled={!canStart}>
+              Starte Simulation
+            </button>
+            <button type="button" onClick={endSimulation} disabled={!canStop}>
+              Simulation beenden
+            </button>
+          </div>
+          {conversationId && (
+            <p className={styles.meta}>Konversation-ID: {conversationId}</p>
+          )}
+          {error && <p className={styles.error}>{error}</p>}
+          <audio ref={audioRef} autoPlay className={styles.audio} />
+        </section>
+
+        <section className={styles.card}>
+          <h2>Transkript</h2>
+          <p>
+            Nach dem Gespräch kannst du das Transkript speichern oder erneut laden, sobald es
+            verarbeitet wurde.
+          </p>
+          <textarea
+            placeholder="Transkript hier einfügen oder bearbeiten"
+            rows={6}
+            value={transcriptDraft}
+            onChange={(event) => setTranscriptDraft(event.target.value)}
+          />
+          <div className={styles.actions}>
+            <button type="button" onClick={saveTranscript} disabled={!transcriptDraft}>
+              Transkript speichern
+            </button>
+            <button type="button" onClick={fetchTranscript} disabled={!conversationId}>
+              Transkript anzeigen
+            </button>
+          </div>
+          {transcript && <pre className={styles.transcript}>{transcript}</pre>}
+        </section>
+
+        <section className={styles.card}>
+          <h2>Scoreboard</h2>
+          <p>Fordere eine Bewertung der Unterhaltung anhand der Kriterien Klarheit, Bedarf und Einwände an.</p>
+          <button type="button" onClick={requestScore} disabled={!conversationId}>
+            Score berechnen
+          </button>
+          {score && (
+            <div className={styles.scorePanel}>
+              <div className={styles.scoreValue}>{score.score}</div>
+              <p>{score.feedback}</p>
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/hooks/useSimulation.ts
+++ b/frontend/src/hooks/useSimulation.ts
@@ -1,0 +1,210 @@
+import { useCallback, useRef, useState } from 'react';
+
+type SimulationStatus = 'idle' | 'starting' | 'live' | 'ended' | 'error';
+
+type ScoreResponse = {
+  score: number;
+  feedback: string;
+};
+
+type ConversationPayload = {
+  id: string;
+  transcript: string | null;
+  score: number | null;
+  feedback: string | null;
+  createdAt: string;
+};
+
+const API_HEADERS = import.meta.env.VITE_API_KEY
+  ? { 'x-api-key': import.meta.env.VITE_API_KEY as string }
+  : undefined;
+
+export const useSimulation = () => {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
+  const localStreamRef = useRef<MediaStream | null>(null);
+
+  const [status, setStatus] = useState<SimulationStatus>('idle');
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<string | null>(null);
+  const [score, setScore] = useState<ScoreResponse | null>(null);
+  const [transcriptDraft, setTranscriptDraft] = useState('');
+
+  const cleanupMedia = useCallback(() => {
+    peerConnectionRef.current?.getSenders().forEach((sender) => sender.track?.stop());
+    peerConnectionRef.current?.close();
+    peerConnectionRef.current = null;
+
+    localStreamRef.current?.getTracks().forEach((track) => track.stop());
+    localStreamRef.current = null;
+  }, []);
+
+  const startSimulation = useCallback(async () => {
+    try {
+      setError(null);
+      setStatus('starting');
+
+      const startResponse = await fetch('/api/start', {
+        method: 'POST',
+        headers: {
+          ...(API_HEADERS ?? {})
+        }
+      });
+
+      if (!startResponse.ok) {
+        throw new Error('Konnte die Simulation nicht starten.');
+      }
+
+      const startPayload: { conversationId: string } = await startResponse.json();
+      setConversationId(startPayload.conversationId);
+
+      const tokenResponse = await fetch('/api/token', {
+        method: 'POST',
+        headers: {
+          ...(API_HEADERS ?? {})
+        }
+      });
+
+      if (!tokenResponse.ok) {
+        throw new Error('Konnte kein Ephemeral Token erzeugen.');
+      }
+
+      const { token } = (await tokenResponse.json()) as { token: string };
+
+      const localStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      localStreamRef.current = localStream;
+
+      const pc = new RTCPeerConnection({
+        iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+      });
+      peerConnectionRef.current = pc;
+
+      localStream.getTracks().forEach((track) => pc.addTrack(track, localStream));
+
+      pc.addEventListener('track', (event) => {
+        const [remoteStream] = event.streams;
+        if (audioRef.current) {
+          audioRef.current.srcObject = remoteStream;
+        }
+      });
+
+      const offer = await pc.createOffer({ offerToReceiveAudio: true, voiceActivityDetection: true });
+      await pc.setLocalDescription(offer);
+
+      const sdpResponse = await fetch('/api/realtime/session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(API_HEADERS ?? {})
+        },
+        body: JSON.stringify({
+          token,
+          sdp: offer.sdp,
+          conversationId: startPayload.conversationId
+        })
+      });
+
+      if (!sdpResponse.ok) {
+        throw new Error('Konnte keine Antwort vom Realtime-Service erhalten.');
+      }
+
+      const { sdp: remoteSdp } = (await sdpResponse.json()) as { sdp: string };
+      await pc.setRemoteDescription({ type: 'answer', sdp: remoteSdp });
+
+      setStatus('live');
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : 'Unbekannter Fehler');
+      setStatus('error');
+      cleanupMedia();
+    }
+  }, [cleanupMedia]);
+
+  const endSimulation = useCallback(async () => {
+    cleanupMedia();
+    setStatus('ended');
+  }, [cleanupMedia]);
+
+  const saveTranscript = useCallback(async () => {
+    if (!conversationId) {
+      return;
+    }
+
+    const response = await fetch(`/api/conversation/${conversationId}/transcript`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(API_HEADERS ?? {})
+      },
+      body: JSON.stringify({ transcript: transcriptDraft })
+    });
+
+    if (!response.ok) {
+      throw new Error('Transkript konnte nicht gespeichert werden.');
+    }
+
+    const payload = (await response.json()) as ConversationPayload;
+    setTranscript(payload.transcript);
+    setTranscriptDraft('');
+  }, [conversationId, transcriptDraft]);
+
+  const fetchTranscript = useCallback(async () => {
+    if (!conversationId) {
+      return;
+    }
+
+    const response = await fetch(`/api/conversation/${conversationId}`, {
+      headers: {
+        ...(API_HEADERS ?? {})
+      }
+    });
+    if (!response.ok) {
+      throw new Error('Transkript konnte nicht geladen werden.');
+    }
+
+    const payload = (await response.json()) as ConversationPayload;
+    setTranscript(payload.transcript);
+    if (payload.score !== null && payload.feedback !== null) {
+      setScore({ score: payload.score, feedback: payload.feedback });
+    }
+  }, [conversationId]);
+
+  const requestScore = useCallback(async () => {
+    if (!conversationId) {
+      return;
+    }
+
+    const response = await fetch('/api/score', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(API_HEADERS ?? {})
+      },
+      body: JSON.stringify({ conversationId })
+    });
+
+    if (!response.ok) {
+      throw new Error('Score konnte nicht berechnet werden.');
+    }
+
+    const payload = (await response.json()) as ScoreResponse & { conversationId: string };
+    setScore({ score: payload.score, feedback: payload.feedback });
+  }, [conversationId]);
+
+  return {
+    audioRef,
+    conversationId,
+    endSimulation,
+    error,
+    fetchTranscript,
+    requestScore,
+    saveTranscript,
+    score,
+    startSimulation,
+    status,
+    transcript,
+    transcriptDraft,
+    setTranscriptDraft
+  };
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles/App.module.css
+++ b/frontend/src/styles/App.module.css
@@ -1,0 +1,162 @@
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+}
+
+.header p {
+  margin: 0;
+  color: #334155;
+}
+
+.badge {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background-color: #e2e8f0;
+  color: #0f172a;
+}
+
+.badgeLive {
+  background-color: #bbf7d0;
+  color: #166534;
+}
+
+.badgeStarting {
+  background-color: #fef9c3;
+  color: #854d0e;
+}
+
+.badgeEnded {
+  background-color: #e2e8f0;
+}
+
+.badgeError {
+  background-color: #fecdd3;
+  color: #9f1239;
+}
+
+.main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .main {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .main > :last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 15px 35px -20px rgba(15, 23, 42, 0.35);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card h2 {
+  margin: 0;
+}
+
+.card p {
+  margin: 0;
+  color: #475569;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.actions button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.actions button:not(:disabled):hover {
+  opacity: 0.85;
+}
+
+.meta {
+  font-size: 0.875rem;
+  color: #0f172a;
+}
+
+.error {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.audio {
+  width: 100%;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 120px;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.transcript {
+  background: #f1f5f9;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  max-height: 280px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  font-size: 0.9rem;
+}
+
+.scorePanel {
+  background: #eff6ff;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.scoreValue {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #1d4ed8;
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,19 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true
+      }
+    }
+  },
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React frontend that handles starting WebRTC sessions, saving transcripts, and requesting AI scoring
- implement a Fastify backend with Prisma persistence, OpenAI integration endpoints, and Realtime session negotiation
- add Docker Compose orchestration plus shared linting/formatting configuration for the monorepo

## Testing
- not run (dependencies unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_b_68dba9aadd60832b93c502c0f99a509f