### PR TITLE
Add error response schemas for backend routes

### DIFF
--- a/backend/src/routes/realtime.ts
+++ b/backend/src/routes/realtime.ts
@@ -15,7 +15,8 @@ export async function realtimeRoutes(app: FastifyInstance) {
           token: z.string().optional()
         }),
         response: {
-          200: z.object({ sdp: z.string() })
+          200: z.object({ sdp: z.string() }),
+          500: z.object({ message: z.string() })
         }
       }
     },

--- a/backend/src/routes/score.ts
+++ b/backend/src/routes/score.ts
@@ -22,6 +22,9 @@ export async function scoreRoutes(app: FastifyInstance) {
             conversationId: z.string(),
             score: z.number(),
             feedback: z.string()
+          }),
+          500: z.object({
+            message: z.string()
           })
         }
       }

--- a/backend/src/routes/token.ts
+++ b/backend/src/routes/token.ts
@@ -18,6 +18,9 @@ export async function tokenRoutes(app: FastifyInstance) {
           200: z.object({
             token: z.string(),
             expires_in: z.number()
+          }),
+          500: z.object({
+            message: z.string()
           })
         }
       }


### PR DESCRIPTION
## Summary
- add explicit 500-level response schemas for realtime, token, and score routes
- allow error responses with a message field to satisfy Fastify type checking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dbb3998c44832ba922dc97ae2f9816