### PR TITLE
Allow start endpoint to accept empty payloads

### DIFF
--- a/backend/src/routes/conversation.ts
+++ b/backend/src/routes/conversation.ts
@@ -14,9 +14,11 @@ export async function conversationRoutes(app: FastifyInstance) {
           .object({
             userId: z.string().optional()
           })
-          .optional(),
+          .optional()
+          .nullable(),
         response: {
-          200: z.object({ conversationId: z.string() })
+          200: z.object({ conversationId: z.string() }),
+          500: z.object({ error: z.string() })
         }
       }
     },


### PR DESCRIPTION
## Summary
- allow the /api/start request body schema to accept null payloads while keeping the userId optional
- declare a 500 error schema for the endpoint to satisfy Fastify type expectations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68f165c736b8832ba18c5a5cf81e0082