### PR TITLE
Add 500 error response schema for conversation start route

### DIFF
--- a/backend/src/routes/conversation.ts
+++ b/backend/src/routes/conversation.ts
@@ -16,7 +16,8 @@ export async function conversationRoutes(app: FastifyInstance) {
           })
           .optional(),
         response: {
-          200: z.object({ conversationId: z.string() })
+          200: z.object({ conversationId: z.string() }),
+          500: z.object({ error: z.string() })
         }
       }
     },


### PR DESCRIPTION
## Summary
- extend the `/api/start` route response schema to include a 500 error payload matching the handler

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68f165cbb02c832b98c901093169d9bf