### PR TITLE
Add CI workflow for linting, testing, Docker publish, and deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,177 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  lint_build:
+    name: Lint & Build (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [backend, frontend]
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Cache npm dependencies
+        id: cache-npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ matrix.project }}-${{ hashFiles('backend/package.json', 'frontend/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ matrix.project }}-
+            ${{ runner.os }}-npm-
+
+      - name: Install dependencies
+        run: npm install --prefer-offline
+
+      - name: Cache Prisma Client
+        if: matrix.project == 'backend'
+        id: cache-prisma
+        uses: actions/cache@v4
+        with:
+          path: backend/node_modules/.prisma
+          key: ${{ runner.os }}-prisma-${{ hashFiles('backend/prisma/schema.prisma') }}-${{ hashFiles('backend/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-prisma-
+
+      - name: Generate Prisma Client
+        if: matrix.project == 'backend'
+        run: npm run prisma:generate
+
+      - name: Run ESLint
+        run: npx eslint . --max-warnings=0
+
+      - name: Build
+        run: npm run build --if-present
+
+  test:
+    name: Test (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    needs: lint_build
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [backend, frontend]
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ matrix.project }}-${{ hashFiles('backend/package.json', 'frontend/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ matrix.project }}-
+            ${{ runner.os }}-npm-
+
+      - name: Install dependencies
+        run: npm install --prefer-offline
+
+      - name: Restore Prisma Client cache
+        if: matrix.project == 'backend'
+        uses: actions/cache/restore@v4
+        with:
+          path: backend/node_modules/.prisma
+          key: ${{ runner.os }}-prisma-${{ hashFiles('backend/prisma/schema.prisma') }}-${{ hashFiles('backend/package.json') }}
+
+      - name: Generate Prisma Client
+        if: matrix.project == 'backend'
+        run: npm run prisma:generate
+
+      - name: Run tests
+        run: npm test --if-present
+
+  docker:
+    name: Build & Push Docker image
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    if: github.ref == 'refs/heads/main'
+    env:
+      REGISTRY_USERNAME: ${{ secrets.GHCR_USERNAME }}
+      REGISTRY_TOKEN: ${{ secrets.GHCR_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            API_KEY=${{ secrets.API_KEY }}
+
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    needs:
+      - docker
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          passphrase: ${{ secrets.SSH_PASSPHRASE }}
+          script: |
+            export API_KEY=${{ secrets.API_KEY }}
+            export REGISTRY_TOKEN=${{ secrets.GHCR_TOKEN }}
+            docker login ${{ env.REGISTRY }} -u ${{ secrets.GHCR_USERNAME }} -p $REGISTRY_TOKEN
+            cd ${{ secrets.DEPLOY_WORKDIR }}
+            docker compose pull
+            docker compose up -d --remove-orphans


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that lints/builds frontend and backend, runs their tests, builds a Docker image, and deploys via SSH
- configure npm and Prisma Client caching within the workflow for faster runs
- reference repository secrets for API key, registry credentials, and remote deployment configuration

## Testing
- not run (CI configuration only)


------
https://chatgpt.com/codex/tasks/task_b_68f167f1a7b4832b9a530d8b80cce478