### PR TITLE
Add automated Postgres backup workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,5 +49,27 @@ services:
       - '${VITE_PORT:-3000}:${VITE_PORT:-3000}'
     command: npm run dev
 
+  db-backup:
+    image: postgres:16-alpine
+    container_name: sales-simulation-db-backup
+    restart: unless-stopped
+    depends_on:
+      - db
+    environment:
+      POSTGRES_HOST: ${POSTGRES_HOST:-db}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_DB: ${POSTGRES_DB:-sales_simulation}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-0 2 * * *}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-}
+      BACKUP_DIR: /backups
+    volumes:
+      - postgres_backups:/backups
+      - ./scripts/backups/run-backup.sh:/usr/local/bin/run-backup.sh:ro
+      - ./scripts/backups/backup-cron.sh:/usr/local/bin/backup-cron.sh:ro
+    entrypoint: ["/bin/sh", "/usr/local/bin/backup-cron.sh"]
+
 volumes:
   postgres_data:
+  postgres_backups:

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,0 +1,67 @@
+# Database Backup and Restore
+
+This project includes a cron-driven backup container that regularly exports the PostgreSQL database and stores compressed dumps on a shared volume. Additional helper scripts support syncing those dumps to external object storage and restoring them when needed.
+
+## Backup Service
+
+The `db-backup` service defined in `docker-compose.yml` runs `pg_dump` on the schedule specified by `BACKUP_SCHEDULE` (defaults to `0 2 * * *` for a daily 02:00 UTC backup). The container writes `.sql.gz` files to the shared `postgres_backups` volume.
+
+### Configuration
+
+The service honours the following environment variables (set in your shell or an `.env` file):
+
+- `POSTGRES_HOST` (default `db`)
+- `POSTGRES_PORT` (default `5432`)
+- `POSTGRES_DB` (default `sales_simulation`)
+- `POSTGRES_USER` (default `postgres`)
+- `PGPASSWORD` (**required**)
+- `BACKUP_SCHEDULE` (cron expression, default `0 2 * * *`)
+- `BACKUP_RETENTION_DAYS` (optional number of days to retain backups)
+
+Backups are stored in `/backups` inside the container and exposed locally through the named Docker volume `postgres_backups`.
+
+## Syncing Backups to External Storage
+
+Use the `scripts/backups/sync-to-s3.sh` helper to copy backups to any S3-compatible bucket:
+
+```bash
+export AWS_ACCESS_KEY_ID=... # or configure with `aws configure`
+export AWS_SECRET_ACCESS_KEY=...
+export S3_BUCKET=s3://my-bucket/postgres-backups
+./scripts/backups/sync-to-s3.sh
+```
+
+Optional variables:
+
+- `BACKUP_DIR` (defaults to `./backups`) – set to the mounted backup directory when running outside Docker, e.g. `BACKUP_DIR=~/postgres_backups`.
+- `AWS_PROFILE` – use a named AWS CLI profile instead of environment variables.
+
+The script relies on the AWS CLI being installed locally. For S3-compatible storage (e.g., MinIO, DigitalOcean Spaces), configure the appropriate endpoint using the AWS CLI `--endpoint-url` flag or profile configuration.
+
+## Restoring a Backup
+
+1. Ensure the target database is running and accessible.
+2. Copy the desired `.sql.gz` file from the backup volume or external storage to your workstation.
+3. Run the restore script, providing a connection string or psql flags:
+
+   ```bash
+   ./scripts/backups/restore-from-backup.sh path/to/sales_simulation-20240101T020000Z.sql.gz "postgresql://postgres:postgres@localhost:5432/sales_simulation"
+   ```
+
+   Alternatively, pass standard `psql` arguments:
+
+   ```bash
+   ./scripts/backups/restore-from-backup.sh path/to/backup.sql.gz -h localhost -U postgres -d sales_simulation
+   ```
+
+The script decompresses the archive and streams it directly into `psql`, overwriting the existing data. Consider taking a snapshot of the target database before performing the restore.
+
+## Accessing Local Backup Files
+
+To access the raw backup files created by Docker, mount the `postgres_backups` volume:
+
+```bash
+docker run --rm -v web-app-agents-sdk_postgres_backups:/backups -v $(pwd)/backups:/export busybox cp /backups/* /export/
+```
+
+Replace `web-app-agents-sdk_postgres_backups` with the actual volume name if different. Once exported, the files can be archived, synced, or inspected with standard tools.

--- a/scripts/backups/backup-cron.sh
+++ b/scripts/backups/backup-cron.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+: "${BACKUP_SCHEDULE:=0 2 * * *}"
+: "${POSTGRES_HOST:=db}"
+: "${POSTGRES_PORT:=5432}"
+: "${POSTGRES_DB:=sales_simulation}"
+: "${POSTGRES_USER:=postgres}"
+: "${PGPASSWORD:?PGPASSWORD is required for the backup service}"
+: "${BACKUP_DIR:=/backups}"
+
+RUNNER=/usr/local/bin/run-backup.sh
+
+cat <<CRON >/etc/crontabs/root
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+${BACKUP_SCHEDULE} ${RUNNER}
+CRON
+
+chmod 600 /etc/crontabs/root
+
+echo "[backup-cron] Backups will run on schedule: ${BACKUP_SCHEDULE}" >&2
+/usr/sbin/crond -f -l 8

--- a/scripts/backups/restore-from-backup.sh
+++ b/scripts/backups/restore-from-backup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <path-to-backup.sql.gz> [psql-options...]" >&2
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+shift
+
+echo "Restoring backup from $BACKUP_FILE" >&2
+
+gzip -dc "$BACKUP_FILE" | psql "$@"

--- a/scripts/backups/run-backup.sh
+++ b/scripts/backups/run-backup.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+FILENAME="${POSTGRES_DB:-database}-${TIMESTAMP}.sql.gz"
+TARGET_DIR="${BACKUP_DIR:-/backups}"
+TMP_FILE="${TARGET_DIR}/${FILENAME}"
+
+mkdir -p "$TARGET_DIR"
+
+pg_dump \
+  --host "${POSTGRES_HOST:-db}" \
+  --port "${POSTGRES_PORT:-5432}" \
+  --username "${POSTGRES_USER:-postgres}" \
+  --format=plain \
+  --dbname "${POSTGRES_DB:-postgres}" \
+  | gzip > "$TMP_FILE"
+
+# prune old backups if retention specified
+if [ -n "${BACKUP_RETENTION_DAYS:-}" ]; then
+  find "$TARGET_DIR" -type f -name "${POSTGRES_DB:-database}-*.sql.gz" -mtime "+${BACKUP_RETENTION_DAYS}" -print -delete
+fi
+
+echo "[run-backup] Created backup ${TMP_FILE}" >&2

--- a/scripts/backups/sync-to-s3.sh
+++ b/scripts/backups/sync-to-s3.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required. Install it from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2
+  exit 1
+fi
+
+: "${BACKUP_DIR:=./backups}"
+: "${S3_BUCKET:?S3_BUCKET must be set (e.g. s3://my-bucket/backups)}"
+: "${AWS_PROFILE:=}"
+
+SYNC_ARGS="--delete"
+
+if [ -n "$AWS_PROFILE" ]; then
+  aws --profile "$AWS_PROFILE" s3 sync "$BACKUP_DIR" "$S3_BUCKET" $SYNC_ARGS
+else
+  aws s3 sync "$BACKUP_DIR" "$S3_BUCKET" $SYNC_ARGS
+fi


### PR DESCRIPTION
## Summary
- add a cron-driven `db-backup` service that writes pg_dump archives to a shared volume
- provide helper scripts for running backups, syncing dumps to S3-compatible storage, and restoring archives
- document backup configuration, off-site sync, and restore instructions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68f167f9b4cc832b8e6bb1cb57331428