### PR TITLE
Add speaker awareness and UI feedback to simulation

### DIFF
--- a/frontend/src/hooks/useSimulation.ts
+++ b/frontend/src/hooks/useSimulation.ts
@@ -1,6 +1,9 @@
 import { useCallback, useRef, useState } from 'react';
 
 type SimulationStatus = 'idle' | 'starting' | 'live' | 'ended' | 'error';
+type SpeakerState = 'idle' | 'ai' | 'user';
+type ScorePhase = 'idle' | 'loading' | 'ready' | 'error';
+type TranscriptPhase = 'idle' | 'loading' | 'saving';
 
 type ScoreResponse = {
   score: number;
@@ -23,6 +26,10 @@ export const useSimulation = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
   const localStreamRef = useRef<MediaStream | null>(null);
+  const dataChannelRef = useRef<RTCDataChannel | null>(null);
+  const aiSpeakingRef = useRef(false);
+  const userSpeakingRef = useRef(false);
+  const idleTimeoutRef = useRef<number | null>(null);
 
   const [status, setStatus] = useState<SimulationStatus>('idle');
   const [conversationId, setConversationId] = useState<string | null>(null);
@@ -30,20 +37,131 @@ export const useSimulation = () => {
   const [transcript, setTranscript] = useState<string | null>(null);
   const [score, setScore] = useState<ScoreResponse | null>(null);
   const [transcriptDraft, setTranscriptDraft] = useState('');
+  const [speakerState, setSpeakerState] = useState<SpeakerState>('idle');
+  const [scorePhase, setScorePhase] = useState<ScorePhase>('idle');
+  const [transcriptPhase, setTranscriptPhase] = useState<TranscriptPhase>('idle');
+
+  const updateSpeakerState = useCallback((next: SpeakerState) => {
+    setSpeakerState(next);
+  }, []);
+
+  const setIdleWithDelay = useCallback(() => {
+    if (idleTimeoutRef.current) {
+      window.clearTimeout(idleTimeoutRef.current);
+    }
+
+    idleTimeoutRef.current = window.setTimeout(() => {
+      if (!aiSpeakingRef.current && !userSpeakingRef.current) {
+        updateSpeakerState('idle');
+      }
+    }, 250);
+  }, [updateSpeakerState]);
+
+  const attachRemoteTrackListeners = useCallback(
+    (track: MediaStreamTrack) => {
+      const handleUnmute = () => {
+        aiSpeakingRef.current = true;
+        updateSpeakerState('ai');
+      };
+
+      const handleMute = () => {
+        aiSpeakingRef.current = false;
+        if (userSpeakingRef.current) {
+          updateSpeakerState('user');
+        } else {
+          setIdleWithDelay();
+        }
+      };
+
+      track.addEventListener('unmute', handleUnmute);
+      track.addEventListener('mute', handleMute);
+      track.addEventListener('ended', handleMute);
+
+      return () => {
+        track.removeEventListener('unmute', handleUnmute);
+        track.removeEventListener('mute', handleMute);
+        track.removeEventListener('ended', handleMute);
+      };
+    },
+    [setIdleWithDelay, updateSpeakerState]
+  );
+
+  const teardownRemoteTrackListenersRef = useRef<(() => void) | null>(null);
+
+  const handleVadMessage = useCallback(
+    (rawMessage: string) => {
+      try {
+        const payload = JSON.parse(rawMessage);
+        if (!payload || typeof payload !== 'object') {
+          return;
+        }
+
+        if ('type' in payload && payload.type === 'server_vad') {
+          const status =
+            (typeof payload.status === 'string' && payload.status) ||
+            (typeof payload.event === 'string' && payload.event) ||
+            (payload.data && typeof payload.data.status === 'string' && payload.data.status);
+
+          if (!status) {
+            return;
+          }
+
+          const normalized = status.toLowerCase();
+          if (normalized.includes('start')) {
+            userSpeakingRef.current = true;
+            updateSpeakerState('user');
+          }
+
+          if (normalized.includes('stop') || normalized.includes('end')) {
+            userSpeakingRef.current = false;
+            if (aiSpeakingRef.current) {
+              updateSpeakerState('ai');
+            } else {
+              setIdleWithDelay();
+            }
+          }
+        }
+      } catch (parseError) {
+        console.warn('Unable to parse VAD message', parseError);
+      }
+    },
+    [setIdleWithDelay, updateSpeakerState]
+  );
 
   const cleanupMedia = useCallback(() => {
+    if (idleTimeoutRef.current) {
+      window.clearTimeout(idleTimeoutRef.current);
+      idleTimeoutRef.current = null;
+    }
+
+    teardownRemoteTrackListenersRef.current?.();
+    teardownRemoteTrackListenersRef.current = null;
+
+    dataChannelRef.current?.close();
+    dataChannelRef.current = null;
+
     peerConnectionRef.current?.getSenders().forEach((sender) => sender.track?.stop());
     peerConnectionRef.current?.close();
     peerConnectionRef.current = null;
 
     localStreamRef.current?.getTracks().forEach((track) => track.stop());
     localStreamRef.current = null;
-  }, []);
+
+    aiSpeakingRef.current = false;
+    userSpeakingRef.current = false;
+    updateSpeakerState('idle');
+  }, [updateSpeakerState]);
 
   const startSimulation = useCallback(async () => {
     try {
       setError(null);
       setStatus('starting');
+      setTranscript(null);
+      setTranscriptDraft('');
+      setScore(null);
+      setScorePhase('idle');
+      setTranscriptPhase('idle');
+      updateSpeakerState('idle');
 
       const startResponse = await fetch('/api/start', {
         method: 'POST',
@@ -87,6 +205,20 @@ export const useSimulation = () => {
         if (audioRef.current) {
           audioRef.current.srcObject = remoteStream;
         }
+
+        teardownRemoteTrackListenersRef.current?.();
+        const remoteTrack = event.track;
+        teardownRemoteTrackListenersRef.current = attachRemoteTrackListeners(remoteTrack);
+      });
+
+      pc.addEventListener('datachannel', (event) => {
+        const channel = event.channel;
+        dataChannelRef.current = channel;
+        channel.onmessage = (messageEvent) => {
+          if (typeof messageEvent.data === 'string') {
+            handleVadMessage(messageEvent.data);
+          }
+        };
       });
 
       const offer = await pc.createOffer({ offerToReceiveAudio: true, voiceActivityDetection: true });
@@ -119,7 +251,7 @@ export const useSimulation = () => {
       setStatus('error');
       cleanupMedia();
     }
-  }, [cleanupMedia]);
+  }, [attachRemoteTrackListeners, cleanupMedia, handleVadMessage, updateSpeakerState]);
 
   const endSimulation = useCallback(async () => {
     cleanupMedia();
@@ -131,22 +263,30 @@ export const useSimulation = () => {
       return;
     }
 
-    const response = await fetch(`/api/conversation/${conversationId}/transcript`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(API_HEADERS ?? {})
-      },
-      body: JSON.stringify({ transcript: transcriptDraft })
-    });
+    try {
+      setTranscriptPhase('saving');
+      const response = await fetch(`/api/conversation/${conversationId}/transcript`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(API_HEADERS ?? {})
+        },
+        body: JSON.stringify({ transcript: transcriptDraft })
+      });
 
-    if (!response.ok) {
-      throw new Error('Transkript konnte nicht gespeichert werden.');
+      if (!response.ok) {
+        throw new Error('Transkript konnte nicht gespeichert werden.');
+      }
+
+      const payload = (await response.json()) as ConversationPayload;
+      setTranscript(payload.transcript);
+      setTranscriptDraft('');
+      setTranscriptPhase('idle');
+    } catch (err) {
+      console.error(err);
+      setTranscriptPhase('idle');
+      setError(err instanceof Error ? err.message : 'Unbekannter Fehler beim Speichern des Transkripts');
     }
-
-    const payload = (await response.json()) as ConversationPayload;
-    setTranscript(payload.transcript);
-    setTranscriptDraft('');
   }, [conversationId, transcriptDraft]);
 
   const fetchTranscript = useCallback(async () => {
@@ -154,19 +294,28 @@ export const useSimulation = () => {
       return;
     }
 
-    const response = await fetch(`/api/conversation/${conversationId}`, {
-      headers: {
-        ...(API_HEADERS ?? {})
+    try {
+      setTranscriptPhase('loading');
+      const response = await fetch(`/api/conversation/${conversationId}`, {
+        headers: {
+          ...(API_HEADERS ?? {})
+        }
+      });
+      if (!response.ok) {
+        throw new Error('Transkript konnte nicht geladen werden.');
       }
-    });
-    if (!response.ok) {
-      throw new Error('Transkript konnte nicht geladen werden.');
-    }
 
-    const payload = (await response.json()) as ConversationPayload;
-    setTranscript(payload.transcript);
-    if (payload.score !== null && payload.feedback !== null) {
-      setScore({ score: payload.score, feedback: payload.feedback });
+      const payload = (await response.json()) as ConversationPayload;
+      setTranscript(payload.transcript);
+      if (payload.score !== null && payload.feedback !== null) {
+        setScore({ score: payload.score, feedback: payload.feedback });
+        setScorePhase('ready');
+      }
+      setTranscriptPhase('idle');
+    } catch (err) {
+      console.error(err);
+      setTranscriptPhase('idle');
+      setError(err instanceof Error ? err.message : 'Unbekannter Fehler beim Laden des Transkripts');
     }
   }, [conversationId]);
 
@@ -175,21 +324,29 @@ export const useSimulation = () => {
       return;
     }
 
-    const response = await fetch('/api/score', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(API_HEADERS ?? {})
-      },
-      body: JSON.stringify({ conversationId })
-    });
+    try {
+      setScorePhase('loading');
+      const response = await fetch('/api/score', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(API_HEADERS ?? {})
+        },
+        body: JSON.stringify({ conversationId })
+      });
 
-    if (!response.ok) {
-      throw new Error('Score konnte nicht berechnet werden.');
+      if (!response.ok) {
+        throw new Error('Score konnte nicht berechnet werden.');
+      }
+
+      const payload = (await response.json()) as ScoreResponse & { conversationId: string };
+      setScore({ score: payload.score, feedback: payload.feedback });
+      setScorePhase('ready');
+    } catch (err) {
+      console.error(err);
+      setScorePhase('error');
+      setError(err instanceof Error ? err.message : 'Unbekannter Fehler bei der Score-Berechnung');
     }
-
-    const payload = (await response.json()) as ScoreResponse & { conversationId: string };
-    setScore({ score: payload.score, feedback: payload.feedback });
   }, [conversationId]);
 
   return {
@@ -198,12 +355,15 @@ export const useSimulation = () => {
     endSimulation,
     error,
     fetchTranscript,
+    scorePhase,
+    speakerState,
     requestScore,
     saveTranscript,
     score,
     startSimulation,
     status,
     transcript,
+    transcriptPhase,
     transcriptDraft,
     setTranscriptDraft
   };

--- a/frontend/src/styles/App.module.css
+++ b/frontend/src/styles/App.module.css
@@ -112,6 +112,92 @@
   opacity: 0.85;
 }
 
+.speakerStatus {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.speakerPill {
+  flex: 1 1 220px;
+  background: #f1f5f9;
+  border-radius: 0.875rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.speakerPillActive {
+  box-shadow: 0 12px 30px -16px rgba(29, 78, 216, 0.45);
+  transform: translateY(-2px);
+  color: #0f172a;
+}
+
+.speakerPillUser {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(59, 130, 246, 0.3));
+}
+
+.speakerPillAi {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.15), rgba(16, 185, 129, 0.3));
+}
+
+.speakerMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.speakerLabel {
+  font-weight: 600;
+}
+
+.speakerDescription {
+  font-size: 0.8rem;
+  color: #1f2937;
+}
+
+.voiceWave {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.25rem;
+  height: 1.5rem;
+}
+
+.voiceWave span {
+  display: block;
+  width: 0.35rem;
+  background: currentColor;
+  border-radius: 999px;
+  animation: wave 1.2s infinite ease-in-out;
+  animation-play-state: paused;
+  opacity: 0.3;
+}
+
+.voiceWave[data-active='true'] span {
+  animation-play-state: running;
+  opacity: 0.8;
+}
+
+.voiceWave span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.voiceWave span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes wave {
+  0%,
+  100% {
+    height: 0.35rem;
+  }
+  50% {
+    height: 1.2rem;
+  }
+}
+
 .meta {
   font-size: 0.875rem;
   color: #0f172a;
@@ -120,6 +206,31 @@
 .error {
   color: #dc2626;
   font-weight: 600;
+}
+
+.errorPanel {
+  background: #fef2f2;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: #991b1b;
+}
+
+.errorPanel button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.errorPanel button:hover {
+  opacity: 0.9;
 }
 
 .audio {
@@ -146,6 +257,34 @@ textarea {
   font-size: 0.9rem;
 }
 
+.helper {
+  font-size: 0.85rem;
+  color: #2563eb;
+  font-weight: 500;
+}
+
+.transcriptSkeleton {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.transcriptSkeleton span {
+  display: block;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #e2e8f0, #f8fafc, #e2e8f0);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.transcriptSkeleton span:nth-child(2) {
+  width: 90%;
+}
+
+.transcriptSkeleton span:nth-child(3) {
+  width: 75%;
+}
+
 .scorePanel {
   background: #eff6ff;
   border-radius: 0.75rem;
@@ -159,4 +298,44 @@ textarea {
   font-size: 2.5rem;
   font-weight: 700;
   color: #1d4ed8;
+}
+
+.scoreSkeleton {
+  display: grid;
+  gap: 0.75rem;
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+}
+
+.scoreSkeletonValue,
+.scoreSkeletonText {
+  height: 1.2rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #e2e8f0, #f8fafc, #e2e8f0);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.scoreSkeletonValue {
+  width: 40%;
+  height: 2.5rem;
+}
+
+.scoreSkeletonText {
+  width: 80%;
+}
+
+.errorInline {
+  color: #dc2626;
+  font-weight: 500;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }


### PR DESCRIPTION
## Summary
- track AI/user voice activity, VAD events, and scoring/transcript phases inside the simulation hook
- render speaker indicators, skeleton states, and retry affordances in the app tied to the enhanced state
- extend styling for animated voice feedback, error panels, and loading placeholders

## Testing
- npm run build *(fails: TypeScript configuration cannot resolve rollup/parseAst and undici-types in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f167fc2634832bb7b7b6d194bdceda