### PR TITLE
Improve error handling for realtime token route

### DIFF
--- a/backend/src/routes/token.ts
+++ b/backend/src/routes/token.ts
@@ -2,7 +2,9 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import fetch from 'node-fetch';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { env } from '../lib/env.js';
 import { getUserPreferences, resolveOpenAIKey } from '../lib/preferences.js';
+import { errorResponseSchema, sendErrorResponse } from './error-response.js';
 
 export async function tokenRoutes(app: FastifyInstance) {
   app.withTypeProvider<ZodTypeProvider>().post(
@@ -25,22 +27,35 @@ export async function tokenRoutes(app: FastifyInstance) {
       }
     },
     async (request, reply) => {
-      const userId = request.body?.userId ?? 'demo-user';
-      const preferences = await getUserPreferences(userId);
-      const model = request.body?.model ?? preferences.realtimeModel ?? env.REALTIME_MODEL;
-      const apiKey = resolveOpenAIKey(preferences);
+      try {
+        const userId = request.body?.userId ?? 'demo-user';
+        const preferences = await getUserPreferences(userId);
+        const model = request.body?.model ?? preferences.realtimeModel ?? env.REALTIME_MODEL;
+        const apiKey = resolveOpenAIKey(preferences);
 
-      const response = await fetch('https://api.openai.com/v1/realtime/sessions', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-          'OpenAI-Beta': 'realtime=v1'
-        },
-        body: JSON.stringify({ model })
-      });
+        const response = await fetch('https://api.openai.com/v1/realtime/sessions', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'OpenAI-Beta': 'realtime=v1'
+          },
+          body: JSON.stringify({ model })
+        });
 
-        throw error;
+        if (!response.ok) {
+          const errorText = await response.text();
+          request.log.error({ err: errorText, route: 'token:create', status: response.status });
+          return sendErrorResponse(reply, 500, 'token.create_failed', 'Failed to create realtime token');
+        }
+
+        const payload = await response.json();
+        return reply.send(payload);
+      } catch (error) {
+        request.log.error({ err: error, route: 'token:create' });
+        const message =
+          error instanceof Error ? error.message : 'Failed to create realtime token';
+        return sendErrorResponse(reply, 500, 'token.create_failed', message);
       }
     }
   );


### PR DESCRIPTION
## Summary
- import the realtime environment settings and shared error helper in the token route
- wrap the realtime session token creation handler in structured try/catch logic
- parse and return the upstream success payload while routing failures through the shared helper

## Testing
- npm run build *(fails: existing syntax errors in conversation.ts, realtime.ts, score.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68f16fe15bf0832baccb8e173aaa6091