### PR TITLE
Fix conversation transcript route imports and error handling

### DIFF
--- a/backend/src/routes/error-response.ts
+++ b/backend/src/routes/error-response.ts
@@ -8,6 +8,7 @@ export const errorResponseSchema = z.object({
   context: z.record(z.any()).optional()
 });
 
+export type ErrorResponse = z.infer<typeof errorResponseSchema>;
 export type ErrorResponseContext = Record<string, unknown> | undefined;
 
 export function sendErrorResponse(


### PR DESCRIPTION
## Summary
- import missing Prisma and error response helpers in the conversation routes
- wrap the transcript update handler in a try/catch and return the updated conversation
- export the ErrorResponse type from the shared error response helper

## Testing
- npm run build *(fails: existing syntax errors in realtime.ts, score.ts, token.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68f16fddbf98832ba13e94efeba2cb4a