### PR TITLE
Refactor score route error handling

### DIFF
--- a/backend/src/routes/score.ts
+++ b/backend/src/routes/score.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
@@ -7,6 +6,8 @@ import { ConversationLogType } from '@prisma/client';
 import { env } from '../lib/env.js';
 import { prisma } from '../lib/prisma.js';
 import { getUserPreferences, resolveOpenAIKey } from '../lib/preferences.js';
+import { ServiceError } from '../services/errors.js';
+import { errorResponseSchema, sendErrorResponse } from './error-response.js';
 
 const systemPrompt = `Bewerte dieses Verkaufsgespräch nach Klarheit, Bedarfsermittlung, Einwandbehandlung.
 Antworte ausschließlich als JSON im Format {"score": number, "feedback": string}.`;
@@ -34,27 +35,179 @@ export async function scoreRoutes(app: FastifyInstance) {
       }
     },
     async (request, reply) => {
-      const { conversationId, transcript: transcriptFromBody } = request.body;
-      const userId = request.body.userId ?? 'demo-user';
-      const preferences = await getUserPreferences(userId);
-      const apiKey = resolveOpenAIKey(preferences);
-      const model = preferences.responsesModel ?? env.RESPONSES_MODEL;
+      try {
+        const { conversationId, transcript: transcriptFromBody } = request.body;
+        const userId = request.body.userId ?? 'demo-user';
+        const preferences = await getUserPreferences(userId);
+        const apiKey = resolveOpenAIKey(preferences);
+        const model = preferences.responsesModel ?? env.RESPONSES_MODEL;
 
-      if (!conversationId && !transcriptFromBody) {
-        return reply.badRequest('conversationId oder transcript erforderlich');
-      }
+        if (!conversationId && !transcriptFromBody) {
+          throw new ServiceError(
+            'BAD_REQUEST',
+            'conversationId oder transcript erforderlich'
+          );
+        }
+
+        const existingConversation = conversationId
+          ? await prisma.conversation.findUnique({ where: { id: conversationId } })
+          : null;
+
+        if (conversationId && !existingConversation) {
+          throw new ServiceError('NOT_FOUND', 'Conversation not found');
+        }
+
+        const transcript = transcriptFromBody ?? existingConversation?.transcript ?? '';
+
+        if (!transcript) {
+          throw new ServiceError('BAD_REQUEST', 'Kein Transkript vorhanden');
+        }
+
+        const response = await fetch('https://api.openai.com/v1/responses', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            model,
+            input: [
+              {
+                role: 'system',
+                content: [
+                  {
+                    type: 'text',
+                    text: systemPrompt
+                  }
+                ]
+              },
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'text',
+                    text: transcript
+                  }
+                ]
+              }
+            ]
+          })
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          request.log.error({ errorText }, 'Failed to fetch score from OpenAI');
+
+          throw new ServiceError('UPSTREAM_ERROR', 'Score request failed', {
+            cause: new Error(errorText)
+          });
+        }
+
+        const responseText = await response.text();
+        const lines = responseText.split('\n\n');
+        let aggregated = '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data:')) {
+            continue;
+          }
+
+          const data = line.slice(5).trim();
+          if (!data || data === '[DONE]') {
+            continue;
+          }
+
+          try {
+            const parsed = JSON.parse(data) as {
+              type?: string;
+              delta?: string;
+              content?: Array<{ text?: string }>;
+              text?: string;
+            };
+
+            if (parsed.type === 'response.output_text.delta' && parsed.delta) {
+              aggregated += parsed.delta;
+            } else if (parsed.type === 'response.output_text.done') {
+              if (parsed.text) {
+                aggregated += parsed.text;
+              }
+            } else if (Array.isArray(parsed.content) && parsed.content[0]?.text) {
+              aggregated += parsed.content[0].text ?? '';
+            } else if (typeof parsed.text === 'string') {
+              aggregated += parsed.text;
+            }
+          } catch (error) {
+            // Ignore malformed lines
+          }
+        }
+
+        const parsed = parseScorePayload(aggregated, request.log);
+
+        if (!parsed) {
+          request.log.error({ aggregated }, 'Failed to parse score payload');
+
+          throw new ServiceError(
+            'UPSTREAM_ERROR',
+            'Antwort konnte nicht interpretiert werden'
+          );
+        }
+
+        const boundedScore = Math.min(100, Math.max(0, Math.round(parsed.score)));
+
+        const persistedConversation = await persistConversation({
+          existingConversationId: conversationId,
+          userId,
+          transcript,
+          score: boundedScore,
+          feedback: parsed.feedback
+        });
+
+        await prisma.conversationLog.create({
+          data: {
+            conversationId: persistedConversation.id,
+            role: 'system',
+            type: ConversationLogType.SCORING_CONTEXT,
+            content: aggregated,
+            context: {
+              feedback: parsed.feedback,
+              score: boundedScore
+            }
+          }
+        });
+
+        const result = {
+          conversationId: persistedConversation.id,
+          score: boundedScore,
+          feedback: parsed.feedback
+        };
 
         return reply.send(result);
       } catch (error) {
         if (error instanceof ServiceError) {
           switch (error.code) {
             case 'BAD_REQUEST':
-              return reply.badRequest(error.message);
+              return sendErrorResponse(
+                reply,
+                400,
+                'score.bad_request',
+                error.message
+              );
             case 'NOT_FOUND':
-              return reply.notFound(error.message);
+              return sendErrorResponse(
+                reply,
+                404,
+                'score.not_found',
+                error.message,
+                { conversationId: request.body.conversationId }
+              );
             case 'UPSTREAM_ERROR':
-              request.log.error(error, 'Failed to fetch score from OpenAI');
-              return reply.status(500).send({ message: error.message });
+              request.log.error({ error }, 'Failed to fetch score from OpenAI');
+              return sendErrorResponse(
+                reply,
+                500,
+                'score.upstream_error',
+                error.message
+              );
             default:
               break;
           }
@@ -86,101 +239,18 @@ function parseScorePayload(
   return null;
 }
 
-      const response = await fetch('https://api.openai.com/v1/responses', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          model,
-          input: [
-            {
-              role: 'system',
-              content: [
-                {
-                  type: 'text',
-                  text: systemPrompt
-                }
-              ]
-            },
-            {
-              role: 'user',
-              content: [
-                {
-                  type: 'text',
-                  text: transcript
-                }
-              ]
-            }
-          ]
-        })
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        request.log.error({ errorText }, 'Failed to fetch score from OpenAI');
-        return reply.status(500).send({ message: 'Score request failed' });
-      }
-
-  for (const line of lines) {
-    if (!line.startsWith('data:')) {
-      continue;
-    }
-
-    const data = line.slice(5).trim();
-    if (!data || data === '[DONE]') {
-      continue;
-    }
-
-    try {
-      const parsed = JSON.parse(data) as { type?: string; delta?: string; content?: Array<{ text?: string }>; text?: string };
-
-      if (parsed.type === 'response.output_text.delta' && parsed.delta) {
-        aggregated += parsed.delta;
-      } else if (parsed.type === 'response.output_text.done') {
-        if (parsed.text) {
-          aggregated += parsed.text;
-        }
-      } else if (Array.isArray(parsed.content) && parsed.content[0]?.text) {
-        aggregated += parsed.content[0].text ?? '';
-      } else if (typeof parsed.text === 'string') {
-        aggregated += parsed.text;
-      }
-    } catch (error) {
-      // Ignore malformed lines
-    }
-  }
-
-  return aggregated;
-}
-
-      const boundedScore = Math.min(100, Math.max(0, Math.round(parsed.score)));
-
-      const updatedConversation = conversationId
-        ? await prisma.conversation.update({
-            where: { id: conversationId },
-            data: { score: boundedScore, feedback: parsed.feedback }
-          })
-        : await prisma.conversation.create({
-            data: {
-              userId,
-              transcript,
-              score: boundedScore,
-              feedback: parsed.feedback
-            }
-          });
-
 async function persistConversation({
   existingConversationId,
   transcript,
   score,
-  feedback
+  feedback,
+  userId
 }: {
   existingConversationId?: string;
   transcript: string;
   score: number;
   feedback: string;
+  userId: string;
 }) {
   if (existingConversationId) {
     return prisma.conversation.update({
@@ -191,7 +261,7 @@ async function persistConversation({
 
   return prisma.conversation.create({
     data: {
-      userId: 'demo-user',
+      userId,
       transcript,
       score,
       feedback


### PR DESCRIPTION
## Summary
- import missing error helpers and wrap the /api/score handler body in a try/catch
- move the OpenAI request, streaming aggregation, and persistence logic into the handler and log SCORING_CONTEXT records
- update the persistence helper to use the current user id when creating conversations

## Testing
- npm run build *(fails: existing TypeScript syntax errors in conversation.ts, realtime.ts, and token.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68f16fe0b938832b9fc9918aabf57770