### PR TITLE
Add analytics types and fix conversation log import

### DIFF
--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,5 +1,4 @@
-import type { Conversation } from '@prisma/client';
-import type { UserPreference } from '@prisma/client';
+import type { Conversation, ConversationLog, UserPreference } from '@prisma/client';
 
 export type ConversationResponse = Conversation;
 export type ConversationLogResponse = ConversationLog;
@@ -13,3 +12,24 @@ export type ConversationDto = {
 };
 
 export type UserPreferenceResponse = UserPreference;
+
+export type AnalyticsSummary = {
+  totalConversations: number;
+  scoredConversations: number;
+  averageScore: number | null;
+  lastConversationAt: string | null;
+  lastSevenDays: number;
+  bestScore: { conversationId: string; score: number } | null;
+  lowestScore: { conversationId: string; score: number } | null;
+};
+
+export type AnalyticsDailyTrend = {
+  date: string;
+  conversations: number;
+  averageScore: number | null;
+};
+
+export type ScoreDistributionBucket = {
+  range: string;
+  count: number;
+};


### PR DESCRIPTION
## Summary
- import ConversationLog from Prisma and re-export it for conversation log responses
- define analytics type aliases that match the shapes returned from analytics helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f1f3d42d2c832baa1ed343bc43efc4