### PR TITLE
Add missing imports to server initialization

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,6 +10,8 @@ import { tokenRoutes } from './routes/token.js';
 import { realtimeRoutes } from './routes/realtime.js';
 import { scoreRoutes } from './routes/score.js';
 import { preferencesRoutes } from './routes/preferences.js';
+import type { ErrorResponse } from './routes/error-response.js';
+import { cacheClient } from './services/cache.js';
 
 export const buildServer = () => {
   const app = Fastify({


### PR DESCRIPTION
## Summary
- add the ErrorResponse type import used in the global error handler
- import the cache client used when closing the Fastify server

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f1f3d499d8832ba33609916d6be91f