### PR TITLE
fix: import error options type for service error

### DIFF
--- a/backend/src/services/errors.ts
+++ b/backend/src/services/errors.ts
@@ -1,3 +1,5 @@
+import type { ErrorOptions } from 'node:errors';
+
 export type ServiceErrorCode = 'BAD_REQUEST' | 'NOT_FOUND' | 'UPSTREAM_ERROR';
 
 export class ServiceError extends Error {


### PR DESCRIPTION
## Summary
- import the ErrorOptions type from `node:errors`
- keep the ServiceError constructor using the typed options parameter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f1f3d5d140832bb7cb20bbc31358ae