### PR TITLE
Refine backend analytics DTO typings

### DIFF
--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -13,14 +13,19 @@ export type ConversationDto = {
 
 export type UserPreferenceResponse = UserPreference;
 
+export type ScoreReference = {
+  conversationId: string;
+  score: number;
+};
+
 export type AnalyticsSummary = {
   totalConversations: number;
   scoredConversations: number;
   averageScore: number | null;
   lastConversationAt: string | null;
   lastSevenDays: number;
-  bestScore: { conversationId: string; score: number } | null;
-  lowestScore: { conversationId: string; score: number } | null;
+  bestScore: ScoreReference | null;
+  lowestScore: ScoreReference | null;
 };
 
 export type AnalyticsDailyTrend = {


### PR DESCRIPTION
## Summary
- introduce a reusable `ScoreReference` type for conversation score metadata
- apply the new type to the analytics DTO exports so they stay consistent with the analytics module

## Testing
- npx eslint . *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68f1f5c01140832b8fab43d2b94f7086