### PR TITLE
Fix backend lint and type regressions

### DIFF
--- a/backend/src/routes/conversation.ts
+++ b/backend/src/routes/conversation.ts
@@ -6,6 +6,7 @@ import { env } from '../lib/env.js';
 import { prisma } from '../lib/prisma.js';
 import { ServiceError } from '../services/errors.js';
 import { createConversation, getConversation } from '../services/conversationService.js';
+import type { ConversationDto } from '../types/index.js';
 import {
   errorResponseSchema,
   sendErrorResponse,

--- a/backend/src/routes/token.ts
+++ b/backend/src/routes/token.ts
@@ -6,6 +6,11 @@ import { env } from '../lib/env.js';
 import { getUserPreferences, resolveOpenAIKey } from '../lib/preferences.js';
 import { errorResponseSchema, sendErrorResponse } from './error-response.js';
 
+const sessionResponseSchema = z.object({
+  token: z.string(),
+  expires_in: z.number()
+});
+
 export async function tokenRoutes(app: FastifyInstance) {
   app.withTypeProvider<ZodTypeProvider>().post(
     '/api/token',
@@ -49,7 +54,7 @@ export async function tokenRoutes(app: FastifyInstance) {
           return sendErrorResponse(reply, 500, 'token.create_failed', 'Failed to create realtime token');
         }
 
-        const payload = await response.json();
+        const payload = sessionResponseSchema.parse(await response.json());
         return reply.send(payload);
       } catch (error) {
         request.log.error({ err: error, route: 'token:create' });

--- a/backend/src/services/errors.ts
+++ b/backend/src/services/errors.ts
@@ -1,14 +1,19 @@
-import type { ErrorOptions } from 'node:errors';
-
 export type ServiceErrorCode = 'BAD_REQUEST' | 'NOT_FOUND' | 'UPSTREAM_ERROR';
+
+export type ServiceErrorOptions = {
+  cause?: unknown;
+};
 
 export class ServiceError extends Error {
   constructor(
     public readonly code: ServiceErrorCode,
     message: string,
-    options?: ErrorOptions
+    options?: ServiceErrorOptions
   ) {
-    super(message, options);
+    super(message);
+    if (options?.cause !== undefined) {
+      this.cause = options.cause;
+    }
     this.name = 'ServiceError';
   }
 }


### PR DESCRIPTION
## Summary
- import the conversation DTO type when serializing transcript updates
- validate the realtime session payload before returning it to clients
- replace the invalid ErrorOptions usage with a safe ServiceError options type

## Testing
- npx eslint . --max-warnings=0 (backend) *(fails: ESLint requires an eslint.config.* file)*
- npx eslint . --max-warnings=0 (frontend) *(fails: ESLint requires an eslint.config.* file)*
- npm run build (backend) *(fails: missing dependency type declarations prior to installation)*

------
https://chatgpt.com/codex/tasks/task_b_68f1f4a76ff4832b87f4b4a535a04f35