### PR TITLE
Fix analytics endpoints and user preferences API

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,7 @@
         "fastify": "^4.28.1",
         "fastify-metrics": "^10.6.0",
         "fastify-type-provider-zod": "^2.1.0",
-        "ioredis": "^5.4.1",
+        "ioredis": "^5.8.1",
         "node-fetch": "^3.3.2",
         "pino": "^9.4.0",
         "prisma": "^5.22.0",

--- a/backend/src/routes/preferences.ts
+++ b/backend/src/routes/preferences.ts
@@ -2,38 +2,56 @@ import type { FastifyInstance } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { getUserPreferences, saveUserPreferences } from '../lib/preferences.js';
+import { sendErrorResponse } from './error-response.js';
 
 const themeEnum = z.enum(['light', 'dark', 'system']);
 
+const preferencesSchema = z.object({
+  userId: z.string(),
+  realtimeModel: z.string(),
+  responsesModel: z.string(),
+  apiKeyOverride: z.string().nullable(),
+  theme: themeEnum
+});
+
+const preferencesResponseSchema = z.object({
+  success: z.literal(true),
+  data: preferencesSchema,
+  timestamp: z.string()
+});
+
 export async function preferencesRoutes(app: FastifyInstance) {
   app.withTypeProvider<ZodTypeProvider>().get(
-    '/api/preferences',
+    '/api/user/preferences',
     {
       schema: {
         querystring: z.object({
           userId: z.string().optional()
         }),
         response: {
-          200: z.object({
-            userId: z.string(),
-            realtimeModel: z.string(),
-            responsesModel: z.string(),
-            apiKeyOverride: z.string().nullable(),
-            theme: themeEnum
-          })
+          200: preferencesResponseSchema
         }
       }
     },
     async (request, reply) => {
-      const userId = request.query.userId ?? 'demo-user';
-      const preferences = await getUserPreferences(userId);
-
-      return reply.send(preferences);
+      try {
+        const userId = request.query.userId ?? 'demo-user';
+        request.log.info({ userId }, 'Fetching user preferences');
+        const preferences = await getUserPreferences(userId);
+        return reply.send({
+          success: true as const,
+          data: preferences,
+          timestamp: new Date().toISOString()
+        });
+      } catch (error) {
+        request.log.error({ err: error }, 'Failed to fetch preferences');
+        return sendErrorResponse(reply, 500, 'PREFERENCES_FETCH_ERROR', 'Failed to fetch preferences');
+      }
     }
   );
 
   app.withTypeProvider<ZodTypeProvider>().post(
-    '/api/preferences',
+    '/api/user/preferences',
     {
       schema: {
         body: z.object({
@@ -44,21 +62,24 @@ export async function preferencesRoutes(app: FastifyInstance) {
           theme: themeEnum
         }),
         response: {
-          200: z.object({
-            userId: z.string(),
-            realtimeModel: z.string(),
-            responsesModel: z.string(),
-            apiKeyOverride: z.string().nullable(),
-            theme: themeEnum
-          })
+          200: preferencesResponseSchema
         }
       }
     },
     async (request, reply) => {
-      const { userId, ...payload } = request.body;
-      const preferences = await saveUserPreferences(userId, payload);
-
-      return reply.send(preferences);
+      try {
+        const { userId, ...payload } = request.body;
+        request.log.info({ userId }, 'Saving user preferences');
+        const preferences = await saveUserPreferences(userId, payload);
+        return reply.send({
+          success: true as const,
+          data: preferences,
+          timestamp: new Date().toISOString()
+        });
+      } catch (error) {
+        request.log.error({ err: error }, 'Failed to save preferences');
+        return sendErrorResponse(reply, 500, 'PREFERENCES_SAVE_ERROR', 'Failed to save preferences');
+      }
     }
   );
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,6 +12,7 @@ import { realtimeRoutes } from './routes/realtime.js';
 import { scoreRoutes } from './routes/score.js';
 import { preferencesRoutes } from './routes/preferences.js';
 import { promptRoutes } from './routes/prompts.js';
+import { analyticsRoutes } from './routes/analytics.js';
 import type { ErrorResponse } from './routes/error-response.js';
 
 export const buildServer = () => {
@@ -105,6 +106,7 @@ export const buildServer = () => {
   app.register(scoreRoutes);
   app.register(preferencesRoutes);
   app.register(promptRoutes);
+  app.register(analyticsRoutes);
 
   return app;
 };

--- a/backend/src/services/analyticsService.ts
+++ b/backend/src/services/analyticsService.ts
@@ -1,0 +1,142 @@
+import type {
+  AnalyticsDailyTrend,
+  AnalyticsSummary,
+  ScoreDistributionBucket
+} from '../types/index.js';
+
+type CacheClient = {
+  isEnabled(): boolean;
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttl?: number): Promise<void>;
+  del?(key: string): Promise<void>;
+};
+
+type CacheRecord<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+const inMemoryCache = new Map<string, CacheRecord<unknown>>();
+const DEFAULT_TTL_SECONDS = (() => {
+  const raw = process.env.CACHE_TTL_SECONDS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 300;
+})();
+
+let cacheClientPromise: Promise<CacheClient | null> | null = null;
+
+async function resolveCacheClient(): Promise<CacheClient | null> {
+  if (!cacheClientPromise) {
+    cacheClientPromise = import('./cache.js')
+      .then((module) => module.cacheClient as CacheClient)
+      .catch(() => null);
+  }
+
+  return cacheClientPromise;
+}
+
+function getCacheKey(...segments: Array<string | number>): string {
+  return segments.join(':');
+}
+
+function getFromMemoryCache<T>(key: string): T | null {
+  const record = inMemoryCache.get(key) as CacheRecord<T> | undefined;
+  if (!record) {
+    return null;
+  }
+
+  if (record.expiresAt < Date.now()) {
+    inMemoryCache.delete(key);
+    return null;
+  }
+
+  return record.value;
+}
+
+function setMemoryCache<T>(key: string, value: T, ttlSeconds: number): void {
+  if (ttlSeconds <= 0) {
+    inMemoryCache.delete(key);
+    return;
+  }
+
+  const expiresAt = Date.now() + ttlSeconds * 1000;
+  inMemoryCache.set(key, { value, expiresAt });
+}
+
+async function getOrSetCache<T>(key: string, ttlSeconds: number, fetcher: () => Promise<T>): Promise<T> {
+  const memoryHit = getFromMemoryCache<T>(key);
+  if (memoryHit !== null) {
+    return memoryHit;
+  }
+
+  const cacheClient = await resolveCacheClient();
+  if (cacheClient?.isEnabled()) {
+    try {
+      const cachedValue = await cacheClient.get(key);
+      if (cachedValue) {
+        const parsed = JSON.parse(cachedValue) as T;
+        setMemoryCache(key, parsed, ttlSeconds);
+        return parsed;
+      }
+    } catch (error) {
+      // ignore cache errors to keep API responsive
+    }
+  }
+
+  const value = await fetcher();
+  try {
+    setMemoryCache(key, value, ttlSeconds);
+    if (cacheClient?.isEnabled()) {
+      await cacheClient.set(key, JSON.stringify(value), ttlSeconds);
+    }
+  } catch (error) {
+    // ignore cache errors
+  }
+
+  return value;
+}
+
+export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
+  const cacheKey = getCacheKey('analytics', 'summary');
+  return getOrSetCache(cacheKey, DEFAULT_TTL_SECONDS, async () => {
+    const { fetchAnalyticsSummary } = await import('../lib/analytics.js');
+    const summary = await fetchAnalyticsSummary();
+    return summary;
+  });
+}
+
+export async function getScoreTrends(days: number): Promise<AnalyticsDailyTrend[]> {
+  const normalizedDays = Math.min(Math.max(Math.trunc(days), 1), 90);
+  const cacheKey = getCacheKey('analytics', 'trends', normalizedDays);
+  return getOrSetCache(cacheKey, DEFAULT_TTL_SECONDS, async () => {
+    const { fetchDailyTrends } = await import('../lib/analytics.js');
+    const trend = await fetchDailyTrends(normalizedDays);
+    return trend;
+  });
+}
+
+export async function getScoreDistribution(): Promise<ScoreDistributionBucket[]> {
+  const cacheKey = getCacheKey('analytics', 'distribution');
+  return getOrSetCache(cacheKey, DEFAULT_TTL_SECONDS, async () => {
+    const { fetchScoreDistribution } = await import('../lib/analytics.js');
+    const distribution = await fetchScoreDistribution();
+    return distribution;
+  });
+}
+
+export async function clearAnalyticsCache(): Promise<void> {
+  inMemoryCache.clear();
+  const cacheClient = await resolveCacheClient();
+  if (!cacheClient?.isEnabled()) {
+    return;
+  }
+
+  await Promise.all([
+    cacheClient.del?.(getCacheKey('analytics', 'summary')),
+    cacheClient.del?.(getCacheKey('analytics', 'distribution'))
+  ]);
+
+  // trends caches are namespaced per day range; best effort removal
+  const trendKeys = Array.from({ length: 90 }, (_, index) => getCacheKey('analytics', 'trends', index + 1));
+  await Promise.all(trendKeys.map((trendKey) => cacheClient.del?.(trendKey)));
+}

--- a/backend/src/services/cache.ts
+++ b/backend/src/services/cache.ts
@@ -56,6 +56,15 @@ class CacheClient {
     }
   }
 
+  async del(key: string): Promise<void> {
+    if (!this.client) {
+      return;
+    }
+
+    await this.connect();
+    await this.client.del(key);
+  }
+
   async disconnect(): Promise<void> {
     if (!this.client) {
       return;

--- a/backend/src/services/scoreService.ts
+++ b/backend/src/services/scoreService.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '@prisma/client';
 import { ServiceError } from './errors.js';
+import { clearAnalyticsCache } from './analyticsService.js';
 
 const systemPrompt = `Bewerte dieses Verkaufsgespräch nach Klarheit, Bedarfsermittlung, Einwandbehandlung.
 Antworte ausschließlich als JSON im Format {"score": number, "feedback": string}.`;
@@ -138,6 +139,7 @@ export async function scoreConversation(
         }
       });
 
+  await clearAnalyticsCache();
   return {
     conversationId: updatedConversation.id,
     score: boundedScore,

--- a/backend/test/integration/server.test.ts
+++ b/backend/test/integration/server.test.ts
@@ -163,6 +163,81 @@ describeIfRuntime('sales simulation API', () => {
       .expect(200);
 
     expect(Array.isArray(promptsResponse.body.prompts)).toBe(true);
+
+    const summaryResponse = await request
+      .get('/api/analytics/summary')
+      .set('x-api-key', 'integration-key')
+      .expect(200);
+
+    expect(summaryResponse.body).toMatchObject({
+      success: true,
+      data: {
+        totalConversations: 1,
+        scoredConversations: 1,
+        averageScore: 92,
+        lastSevenDays: 1,
+        bestScore: { score: 92 },
+        lowestScore: { score: 92 }
+      }
+    });
+
+    const trendsResponse = await request
+      .get('/api/analytics/trends?days=5')
+      .set('x-api-key', 'integration-key')
+      .expect(200);
+
+    expect(trendsResponse.body.success).toBe(true);
+    expect(Array.isArray(trendsResponse.body.data)).toBe(true);
+    expect(trendsResponse.body.data.length).toBe(5);
+
+    const distributionResponse = await request
+      .get('/api/analytics/score-distribution')
+      .set('x-api-key', 'integration-key')
+      .expect(200);
+
+    expect(distributionResponse.body.success).toBe(true);
+    expect(
+      distributionResponse.body.data.some(
+        (bucket: { range: string; count: number }) => bucket.range === '81-100' && bucket.count === 1
+      )
+    ).toBe(true);
+
+    const preferencesResponse = await request
+      .get('/api/user/preferences?userId=integration-user')
+      .set('x-api-key', 'integration-key')
+      .expect(200);
+
+    expect(preferencesResponse.body).toMatchObject({
+      success: true,
+      data: {
+        userId: 'integration-user',
+        realtimeModel: 'test-realtime',
+        responsesModel: 'test-responses',
+        theme: 'system'
+      }
+    });
+
+    const savePreferencesResponse = await request
+      .post('/api/user/preferences')
+      .set('x-api-key', 'integration-key')
+      .send({
+        userId: 'integration-user',
+        realtimeModel: 'updated-realtime',
+        responsesModel: 'updated-responses',
+        apiKeyOverride: null,
+        theme: 'dark'
+      })
+      .expect(200);
+
+    expect(savePreferencesResponse.body).toMatchObject({
+      success: true,
+      data: {
+        userId: 'integration-user',
+        realtimeModel: 'updated-realtime',
+        responsesModel: 'updated-responses',
+        theme: 'dark'
+      }
+    });
   });
 
   afterAll(async () => {

--- a/frontend/src/features/analytics/useAnalyticsData.ts
+++ b/frontend/src/features/analytics/useAnalyticsData.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { API_HEADERS } from '../../utils/api';
+import { API_HEADERS, type ApiResponse } from '../../utils/api';
 import type {
   AnalyticsSummary,
   AnalyticsTrendPoint,
@@ -51,13 +51,23 @@ export function useAnalyticsData(days = 14) {
         throw new Error('Analytics-Daten konnten nicht geladen werden.');
       }
 
-      const [summary, trend, distribution] = await Promise.all([
-        summaryResponse.json() as Promise<AnalyticsSummary>,
-        trendResponse.json() as Promise<AnalyticsTrendPoint[]>,
-        distributionResponse.json() as Promise<ScoreDistributionPoint[]>
+      const [summaryPayload, trendPayload, distributionPayload] = await Promise.all([
+        summaryResponse.json() as Promise<ApiResponse<AnalyticsSummary>>,
+        trendResponse.json() as Promise<ApiResponse<AnalyticsTrendPoint[]>>,
+        distributionResponse.json() as Promise<ApiResponse<ScoreDistributionPoint[]>>
       ]);
 
-      setState({ summary, trend, distribution, loading: false, error: null });
+      if (!summaryPayload.success || !trendPayload.success || !distributionPayload.success) {
+        throw new Error('Analytics-Daten konnten nicht geladen werden.');
+      }
+
+      setState({
+        summary: summaryPayload.data,
+        trend: trendPayload.data,
+        distribution: distributionPayload.data,
+        loading: false,
+        error: null
+      });
     } catch (error) {
       console.error(error);
       setState((previous) => ({

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,3 +1,9 @@
 export const API_HEADERS = import.meta.env.VITE_API_KEY
   ? { 'x-api-key': import.meta.env.VITE_API_KEY as string }
   : undefined;
+
+export type ApiResponse<T> = {
+  success: boolean;
+  data: T;
+  timestamp: string;
+};


### PR DESCRIPTION
## Summary
- add an analytics service with caching and wrap analytics routes in success responses
- expose user preferences at /api/user/preferences with logging and consistent response envelopes
- update frontend analytics hooks and integration tests to consume the new API format

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68f2175849d0832b9e3caf93117074f5