### PR TITLE
Add TEST_ENV environment to CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
   test:
     name: Test (${{ matrix.project }})
     runs-on: ubuntu-latest
+    environment: TEST_ENV
     needs: lint_build
     strategy:
       fail-fast: false
@@ -120,6 +121,7 @@ jobs:
   docker:
     name: Build & Push Docker image
     runs-on: ubuntu-latest
+    environment: TEST_ENV
     needs:
       - test
     if: github.ref == 'refs/heads/main'
@@ -156,6 +158,7 @@ jobs:
   deploy:
     name: Deploy to Production
     runs-on: ubuntu-latest
+    environment: TEST_ENV
     needs:
       - docker
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- configure the test, docker, and deploy CI jobs to run in the TEST_ENV environment so repository secrets are available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f666c44a74832b8c073cc0ed3eb4c0