### PR TITLE
Protect metrics endpoint with admin authentication

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -85,7 +85,10 @@ export const buildServer = () => {
   });
 
   app.addHook('onRequest', async (request, reply) => {
-    if (!request.url.startsWith('/api')) {
+    const path = request.url.split('?')[0];
+    const requiresAdminAuth = path.startsWith('/api') || path === '/metrics';
+
+    if (!requiresAdminAuth) {
       return;
     }
 

--- a/backend/test/unit/metrics-auth.test.ts
+++ b/backend/test/unit/metrics-auth.test.ts
@@ -1,0 +1,37 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import supertest from 'supertest';
+import type { FastifyInstance } from 'fastify';
+
+describe('metrics endpoint authentication', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    vi.stubEnv('API_KEY', 'test-api-key');
+    vi.stubEnv('OPENAI_API_KEY', 'test-openai-key');
+    vi.stubEnv('DATABASE_URL', 'postgres://user:pass@localhost:5432/test');
+    vi.stubEnv('REALTIME_MODEL', 'test-realtime');
+    vi.stubEnv('RESPONSES_MODEL', 'test-responses');
+
+    const { buildServer } = await import('../../src/server.js');
+    app = buildServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('rejects requests without admin token', async () => {
+    await supertest(app.server).get('/metrics').expect(401);
+  });
+
+  it('allows access with a valid admin token', async () => {
+    const response = await supertest(app.server)
+      .get('/metrics')
+      .set('x-api-key', 'test-api-key')
+      .expect(200);
+
+    expect(response.text).toBeTypeOf('string');
+    expect(response.text.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts']
+    include: ['src/**/*.test.ts', 'test/**/*.test.ts']
   }
 });


### PR DESCRIPTION
## Summary
- enforce admin authentication for the metrics endpoint using the existing onRequest hook
- expand the Vitest include globs to cover tests under backend/test and add coverage for metrics access control

## Testing
- npm test -- metrics-auth

------
https://chatgpt.com/codex/tasks/task_b_68f66a96b0b4832b8f93416dca5810d6